### PR TITLE
ICS2-2857: Updated Dependencies

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,14 +3,14 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"      %% "bootstrap-backend-play-28" % "5.22.0",
+    "uk.gov.hmrc"      %% "bootstrap-backend-play-28" % "5.24.0",
     "org.apache.axis2" % "axis2-kernel"               % "1.8.0"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % "5.22.0" % Test,
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % "5.24.0" % Test,
     "com.vladsch.flexmark"   % "flexmark-all"             % "0.36.8" % "test, it",
     "org.scalatestplus.play" %% "scalatestplus-play"      % "5.1.0"  % "test, it",
-    "com.github.tomakehurst" % "wiremock-jre8-standalone" % "2.33.1" % "test, it"
+    "com.github.tomakehurst" % "wiremock-jre8-standalone" % "2.33.2" % "test, it"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.5.8


### PR DESCRIPTION
Was unable to update **flexmark-all** to the latest version due to incompatibility issues, so have left this unchanged at current version.